### PR TITLE
Comment out the about section and contents

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -101,12 +101,14 @@
         <footer>
             <!-- footer space -->
             <div class="container">
+                <!--
                 <h4 class="h4">About</h4>
                 <ul>
                     <li>
                         <a href="https://github.com/yuokada/heroku-csv2athena_schema">github</a>
                     </li>
                 </ul>
+                -->
             </div>
         </footer>
     </nav>


### PR DESCRIPTION
Since the fork ribbon was added, the link to github repository got unnecessary.


- [GitHub Ribbons \| The GitHub Blog](https://github.blog/2008-12-19-github-ribbons/)
- [Pure CSS responsive "Fork me on GitHub" ribbon](http://codepo8.github.io/css-fork-on-github-ribbon/)
